### PR TITLE
Fixed key length issue

### DIFF
--- a/enc
+++ b/enc
@@ -113,10 +113,10 @@ def main():
         key_is_set = False
         while not key_is_set:
             key = getpass.getpass(prompt="Enter encryption/decryption key (16 chars): ").encode()
-            if len(key) >= 16:
+            if len(key) == 16:
                 key_is_set = True
             else:
-                print(f"{red}Key must be at least 16 chars long!{no_color}")
+                print(f"{red}Key must be 16 chars long!{no_color}")
 
         if args.encrypt:
             method, target = args.encrypt

--- a/install_requirements
+++ b/install_requirements
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess,time
 modules=[
     "Crypto",


### PR DESCRIPTION
This pull request includes changes to the `enc` and `install_requirements` files to improve key validation and update the script interpreter.

Key validation improvement:

* [`enc`](diffhunk://#diff-5fb2ab76ed9bda034b192c48c7069359252fccda168d925acc0ae7d316c0b53eL116-R119): Modified the key length check to ensure the encryption/decryption key is exactly 16 characters long, updating the error message accordingly.

Script interpreter update:

* [`install_requirements`](diffhunk://#diff-b5b83b097a5396543750ebb86de1eb7c5b254f9c646866bc3c47a6b262961978L1-R1): Changed the script interpreter from `python` to `python3` to ensure compatibility with Python 3.

Closes #2 